### PR TITLE
[UNFINISHED] Add HTTPS support to Express server.

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -1,4 +1,5 @@
 couch:
+  protocol: SERVER_COUCH_PROTOCOL
   domain: SERVER_COUCH_DOMAIN
   port: SERVER_COUCH_PORT
   username: SERVER_COUCH_USERNAME
@@ -7,7 +8,15 @@ token:
   secret: SERVER_SECRET
   iss: SERVER_JWT_ISS
 server:
+  protocol: SERVER_PROTOCOL
   domain: SERVER_DOMAIN
   port: SERVER_PORT
+  certificate: SERVER_CERTIFICATE_FILE
+  key: SERVER_KEY_FILE
 mail:
+  account: SERVER_MAIL_ACCOUNT
   send: SERVER_SEND_MAIL
+  url:
+    protocol: SERVER_MAIL_URL_PROTOCOL
+    domain: SERVER_MAIL_URL_DOMAIN
+    port: SERVER_MAIL_URL_PORT

--- a/config/default.yml
+++ b/config/default.yml
@@ -8,8 +8,13 @@ token:
   secret: secret
   iss: bicycletouringcompanion.com
 server:
+  protocol: http
   domain: localhost
   port: 8080
 mail:
   account: no-reply@bicycletouringcompanion.com
   send: false
+  url:
+    protocol: http
+    domain: localhost
+    port: 8080

--- a/config/production.yml
+++ b/config/production.yml
@@ -8,7 +8,15 @@ token:
   # secret: env SERVER_SECRET
   iss: bicycletouringcompanion.com
 server:
+  protocol: https
   domain: btc-app-server-1559933658.us-east-1.elb.amazonaws.com
-  port: 80
+  port: 8443
+  # certificate: env SERVER_CERTIFICATE_FILE
+  # key: env SERVER_KEY_FILE
 mail:
+  account: no-reply@bicycletouringcompanion.com
   send: true
+  url:
+    protocol: https
+    domain: btc-server.bicycletouringcompanion.com
+    port: 443

--- a/src/index.js
+++ b/src/index.js
@@ -17,9 +17,24 @@
  * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import http from 'http';
+import https from 'https';
+import fs from 'fs';
+
 import { app } from './app';
 import config from 'config';
 
-const {domain, port} = config.get( 'server' );
-app.listen( port );
-console.log( `Serving at http://${domain}:${port}` );
+const {protocol, domain, port, certificate, key} = config.get( 'server' );
+
+if (protocol == "https") {
+	let certificateFileContents = fs.readFileSync(certificate, 'utf8');
+	let keyFileContents = fs.readFileSync(key, 'utf8');
+	var options = {cert: certificateFileContents, key: keyFileContents};
+
+	https.createServer(options, app).listen(port);
+}
+else {
+	http.createServer(app).listen(port);
+}
+
+console.log( `Serving at ${protocol}://${domain}:${port}` );

--- a/src/util/mailer.js
+++ b/src/util/mailer.js
@@ -25,8 +25,9 @@ import _ from 'underscore';
 const subject = 'Register Your Bicycle Touring Companion Account';
 const mailAccount = config.get( 'mail.account' );
 
-const {domain, port} = config.get( 'server' );
-const api = `http://${domain}:${port}`;
+const { url } = config.get( 'mail' );
+const { protocol, domain, port } = url;
+const api = `${protocol}://${domain}:${port}`;
 
 /** @todo The default transporter is unreliable */
 const transporter = nodemailer.createTransport();
@@ -34,7 +35,7 @@ const transporter = nodemailer.createTransport();
 export function mail( registrant, token ) {
   const registrationTemplate = fs.readFileSync( './emailTemplates/registration.html', 'utf8' );
   const {first, last} = registrant.attributes;
-  const assetDomain = `http://${domain}:${port}`;
+  const assetDomain = `${protocol}://${domain}:${port}`;
   transporter.sendMail( {
     from: mailAccount,
     to: registrant.get( 'email' ),
@@ -47,7 +48,7 @@ export function forgotPassword( registrant, token ) {
   const forgotPasswordTemplate = fs.readFileSync( './emailTemplates/forgotPassword.html', 'utf8' );
   const fpSubject = 'Forgotten Password For Your Bicycle Touring Companion Account';
   const {first, last} = registrant.attributes;
-  const assetDomain = `http://${domain}:${port}`;
+  const assetDomain = `${protocol}://${domain}:${port}`;
   transporter.sendMail( {
     from: mailAccount,
     to: registrant.get( 'email' ),


### PR DESCRIPTION
DO NOT MERGE. This does not yet work in production.

Also, separate config for serving and emailing to allow for different URLs and ports in production.

See also: https://github.com/Tour-de-Force/btc-infrastructure/issues/6

#59